### PR TITLE
Port rawgit CDN links to jsDelivr

### DIFF
--- a/Resource/flymd.html
+++ b/Resource/flymd.html
@@ -18,7 +18,7 @@
     <!--- Source --->
     <!--- https://github.com/showdownjs/showdown --->
     <script type="text/javascript"
-            src="https://cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>
+            src="https://cdn.jsdelivr.net/gh/showdownjs/showdown@1.3.0/dist/showdown.min.js"></script>
 
     <!--- My js file. --->
     <script type="text/javascript"
@@ -35,13 +35,13 @@
         <li><input type="button" id="AutoScroll" value="Auto Scroll"/></li>
       </ul>
     </div>
-    
+
     <article class="markdown-body">
       <span id="replacer">
         <h1>If you see this page, you are so lucky.......</h1>
         <p>Hello, I am Mola-T.</p>
         <p>You can find me at <a href="mailto:mola@molamola.xyz">mola@molamola.xyz</a>.</p>
-        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p> 
+        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p>
         <p>If you see this page, it is most possibly due to browser compatibility problem.</p>
         <p>You can check for the solution here:</p>
         <h3><a href="https://github.com/mola-T/flymd/blob/master/browser.md">https://github.com/mola-T/flymd/blob/master/browser.md</a></h3>

--- a/demo/flymd.html
+++ b/demo/flymd.html
@@ -4,10 +4,10 @@
     <!--- This is the css used by for displaying gfm. --->
     <!--- Source --->
     <!--- https://github.com/sindresorhus/github-markdown-css --->
-    <link rel="stylesheet" href="https://cdn.rawgit.com/mola-T/flymd/master/cdn/github-markdown_1_0_0.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/github-markdown_1_0_0.css">
 
     <!--- My css file to format the page --->
-    <link rel="stylesheet" href="https://cdn.rawgit.com/mola-T/flymd/master/cdn/flymd_1_0_0.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/flymd_1_0_0.css">
 
     <!--- jQuery --->
     <script src="https://code.jquery.com/jquery-2.2.3.min.js"
@@ -18,11 +18,11 @@
     <!--- Source --->
     <!--- https://github.com/showdownjs/showdown --->
     <script type="text/javascript"
-            src="https://cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>
+            src="https://cdn.jsdelivr.net/gh/showdownjs/showdown@1.3.0/dist/showdown.min.js"></script>
 
     <!--- My js file. --->
     <script type="text/javascript"
-            src="https://cdn.rawgit.com/mola-T/flymd/master/cdn/flymd_1_2_0.js"></script>
+            src="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/flymd_1_2_0.js"></script>
   </head>
 
   <body>
@@ -34,13 +34,13 @@
         <li><input type="button" id="AutoScroll" value="Auto Scroll"/></li>
       </ul>
     </div>
-    
+
     <article class="markdown-body">
       <span id="replacer">
         <h1>If you see this page, you are so lucky.......</h1>
         <p>Hello, I am Mola-T.</p>
         <p>You can find me at <a href="mailto:mola@molamola.xyz">mola@molamola.xyz</a>.</p>
-        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p> 
+        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p>
         <p>Seeing this page is not because any error from my codes.</p>
         <p>It is the <strong>FATE</strong> which brought you here!!!!</p>
         <br>

--- a/flymd.html
+++ b/flymd.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+
   <head>
     <!--- This is the css used by for displaying gfm. --->
     <!--- Source --->
     <!--- https://github.com/sindresorhus/github-markdown-css --->
-    <link rel="stylesheet" href="https://cdn.rawgit.com/mola-T/flymd/master/cdn/github-markdown_1_0_0.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/github-markdown_1_0_0.css">
 
     <!--- My css file to format the page --->
-    <link rel="stylesheet" href="https://cdn.rawgit.com/mola-T/flymd/master/cdn/flymd_1_1_0.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/flymd_1_0_0.css">
 
     <!--- jQuery --->
     <script src="https://code.jquery.com/jquery-2.2.3.min.js"
@@ -18,11 +19,11 @@
     <!--- Source --->
     <!--- https://github.com/showdownjs/showdown --->
     <script type="text/javascript"
-            src="https://cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>
+            src="https://cdn.jsdelivr.net/gh/showdownjs/showdown@1.3.0/dist/showdown.min.js"></script>
 
     <!--- My js file. --->
     <script type="text/javascript"
-            src="https://cdn.rawgit.com/mola-T/flymd/master/cdn/flymd_1_3_0.js"></script>
+            src="https://cdn.jsdelivr.net/gh/mola-T/flymd@master/cdn/flymd_1_3_0.js"></script>
   </head>
 
   <body>
@@ -35,13 +36,13 @@
         <li><input type="button" id="AutoScroll" value="Auto Scroll"/></li>
       </ul>
     </div>
-    
+
     <article class="markdown-body">
       <span id="replacer">
         <h1>If you see this page, you are so lucky.......</h1>
         <p>Hello, I am Mola-T.</p>
         <p>You can find me at <a href="mailto:mola@molamola.xyz">mola@molamola.xyz</a>.</p>
-        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p> 
+        <p>It is the github page of this project <a href="https://github.com/mola-T/flymd">https://github.com/mola-T/flymd</a>.</p>
         <p>If you see this page, it is most possibly due to browser compatibility problem.</p>
         <p>You can check for the solution here:</p>
         <h3><a href="https://github.com/mola-T/flymd/blob/master/browser.md">https://github.com/mola-T/flymd/blob/master/browser.md</a></h3>


### PR DESCRIPTION
RawGit (https://rawgit.com/) is going to be shutdown soon. This change switches all the references to rawgit to get contents to instead use jsDelivr as suggested in the rawgit page.

Tests:
- Open demo/flymd.md
- M-x `flymd-flyit`
- Verify in Firefox by viewing Page source that the new flymd.html file is loaded (with jsdelivr based links) and is working properly.

Btw, this is an awesome tool.